### PR TITLE
feat: integrate Grafana Cloud telemetry reachability checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,22 @@
 # Grafana Cloud export is configured in a later phase (main process only).
 
 # -----------------------------------------------------------------------------
+# Telemetry — Grafana Cloud upload (main process only, send phase)
+# -----------------------------------------------------------------------------
+
+# OTLP HTTP endpoint for Grafana Cloud trace export. Read only in the Electron main process.
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-eu-west-0.grafana.net/otlp
+
+# Authorization and other OTLP headers (`key=value` pairs, comma-separated).
+# OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64-instance-id:api-token>
+
+# Optional dedicated reachability probe URL (HEAD). Defaults to `<endpoint>/v1/traces`.
+# GRAFANA_OTLP_HEALTH_URL=https://otlp-gateway-prod-eu-west-0.grafana.net/otlp/v1/traces
+
+# Alias for OTEL_EXPORTER_OTLP_ENDPOINT when only a Grafana-specific name is preferred.
+# GRAFANA_OTLP_ENDPOINT=https://otlp-gateway-prod-eu-west-0.grafana.net/otlp
+
+# -----------------------------------------------------------------------------
 # Host and ports (tooling)
 # -----------------------------------------------------------------------------
 

--- a/src/main/app/register-ipc.ts
+++ b/src/main/app/register-ipc.ts
@@ -1,6 +1,7 @@
 import { registerHealthIpc } from '@main/features/health'
 import { registerSessionsIpc } from '@main/features/sessions'
 import { registerSystemIpc } from '@main/features/system'
+import { registerTelemetryIpc } from '@main/features/telemetry'
 import { registerUsersIpc } from '@main/features/users'
 
 /**
@@ -11,4 +12,5 @@ export function registerIpcHandlers() {
   registerSystemIpc()
   registerUsersIpc()
   registerSessionsIpc()
+  registerTelemetryIpc()
 }

--- a/src/main/features/telemetry/config/otlp-env.test.ts
+++ b/src/main/features/telemetry/config/otlp-env.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseOtlpHeaders, readOtlpExportConfig, resolveGrafanaReachabilityUrl } from './otlp-env'
+
+describe('otlp-env', () => {
+  it('returns null when no OTLP endpoint is configured', () => {
+    expect(readOtlpExportConfig({})).toBeNull()
+  })
+
+  it('reads standard OTLP endpoint and headers from the environment', () => {
+    const config = readOtlpExportConfig({
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com/otlp/',
+      OTEL_EXPORTER_OTLP_HEADERS: 'Authorization=Basic abc123, X-Test=1'
+    })
+
+    expect(config).toEqual({
+      endpoint: 'https://otlp.example.com/otlp',
+      headers: {
+        Authorization: 'Basic abc123',
+        'X-Test': '1'
+      }
+    })
+  })
+
+  it('falls back to GRAFANA_OTLP_ENDPOINT when OTEL endpoint is missing', () => {
+    const config = readOtlpExportConfig({
+      GRAFANA_OTLP_ENDPOINT: 'https://grafana.example/otlp'
+    })
+
+    expect(config?.endpoint).toBe('https://grafana.example/otlp')
+  })
+
+  it('parses OTLP headers and resolves the default health URL', () => {
+    expect(parseOtlpHeaders('Authorization=Basic token')).toEqual({
+      Authorization: 'Basic token'
+    })
+
+    const config = readOtlpExportConfig({
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com'
+    })
+
+    expect(resolveGrafanaReachabilityUrl(config!)).toBe('https://otlp.example.com/v1/traces')
+    expect(
+      resolveGrafanaReachabilityUrl(config!, {
+        GRAFANA_OTLP_HEALTH_URL: 'https://health.example/ping'
+      })
+    ).toBe('https://health.example/ping')
+  })
+
+  it('ignores malformed OTLP header pairs', () => {
+    expect(parseOtlpHeaders('invalid,Authorization=token')).toEqual({
+      Authorization: 'token'
+    })
+    expect(parseOtlpHeaders('=value')).toEqual({})
+    expect(parseOtlpHeaders(' =token,Authorization=token')).toEqual({
+      Authorization: 'token'
+    })
+  })
+})

--- a/src/main/features/telemetry/config/otlp-env.ts
+++ b/src/main/features/telemetry/config/otlp-env.ts
@@ -1,0 +1,79 @@
+/** Resolved OTLP export settings for Grafana Cloud reachability checks. */
+export type OtlpExportConfig = {
+  /** Base OTLP HTTP endpoint without a trailing slash. */
+  endpoint: string
+  /** Optional request headers (e.g. Grafana Cloud authorization). */
+  headers: Record<string, string>
+}
+
+const HEADER_PAIR_SEPARATOR = ','
+
+/**
+ * Parses `OTEL_EXPORTER_OTLP_HEADERS` (`key=value,key2=value2`).
+ *
+ * @param raw Raw header string from the environment.
+ * @returns Header map for fetch requests.
+ */
+export function parseOtlpHeaders(raw: string | undefined): Record<string, string> {
+  if (!raw?.trim()) {
+    return {}
+  }
+
+  return raw.split(HEADER_PAIR_SEPARATOR).reduce<Record<string, string>>((headers, pair) => {
+    const separatorIndex = pair.indexOf('=')
+
+    if (separatorIndex <= 0) {
+      return headers
+    }
+
+    const key = pair.slice(0, separatorIndex).trim()
+    const value = pair.slice(separatorIndex + 1).trim()
+
+    if (key) {
+      headers[key] = value
+    }
+
+    return headers
+  }, {})
+}
+
+/**
+ * Reads Grafana Cloud OTLP settings from the main-process environment.
+ *
+ * @param env Process environment (defaults to `process.env`).
+ * @returns Config when an endpoint is configured, otherwise null.
+ */
+export function readOtlpExportConfig(
+  env: NodeJS.ProcessEnv = process.env
+): OtlpExportConfig | null {
+  const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim() ?? env.GRAFANA_OTLP_ENDPOINT?.trim()
+
+  if (!endpoint) {
+    return null
+  }
+
+  return {
+    endpoint: endpoint.replace(/\/$/, ''),
+    headers: parseOtlpHeaders(env.OTEL_EXPORTER_OTLP_HEADERS)
+  }
+}
+
+/**
+ * Resolves the URL used for Grafana Cloud reachability probes.
+ *
+ * @param config OTLP export configuration.
+ * @param env Process environment (defaults to `process.env`).
+ * @returns Absolute URL for a HEAD request.
+ */
+export function resolveGrafanaReachabilityUrl(
+  config: OtlpExportConfig,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const override = env.GRAFANA_OTLP_HEALTH_URL?.trim()
+
+  if (override) {
+    return override
+  }
+
+  return `${config.endpoint}/v1/traces`
+}

--- a/src/main/features/telemetry/index.ts
+++ b/src/main/features/telemetry/index.ts
@@ -1,3 +1,6 @@
+export { registerTelemetryIpc } from './ipc/register'
+export { checkGrafanaCloudReachability } from './service/grafana-reachability'
+export type { GrafanaReachabilityResult } from './service/grafana-reachability'
 import {
   startLocalCollector,
   stopLocalCollector,

--- a/src/main/features/telemetry/ipc/register.test.ts
+++ b/src/main/features/telemetry/ipc/register.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getIpcHandler } from '../../../test/electron-mock'
+
+vi.mock('../service/grafana-reachability', () => ({
+  checkGrafanaCloudReachability: vi.fn()
+}))
+
+describe('registerTelemetryIpc', () => {
+  it('returns Grafana reachability from the IPC handler', async () => {
+    const { checkGrafanaCloudReachability } = await import('../service/grafana-reachability')
+    vi.mocked(checkGrafanaCloudReachability).mockResolvedValue({ reachable: true })
+
+    const { registerTelemetryIpc } = await import('./register')
+    registerTelemetryIpc()
+
+    await expect(getIpcHandler('telemetry:checkGrafanaReachability')()).resolves.toEqual({
+      reachable: true
+    })
+  })
+})

--- a/src/main/features/telemetry/ipc/register.ts
+++ b/src/main/features/telemetry/ipc/register.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron'
+
+import { checkGrafanaCloudReachability } from '../service/grafana-reachability'
+
+/**
+ * Registers IPC handlers for telemetry connectivity checks.
+ */
+export function registerTelemetryIpc() {
+  ipcMain.handle('telemetry:checkGrafanaReachability', () => {
+    return checkGrafanaCloudReachability()
+  })
+}

--- a/src/main/features/telemetry/service/grafana-reachability.test.ts
+++ b/src/main/features/telemetry/service/grafana-reachability.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { checkGrafanaCloudReachability, isGrafanaReachabilityStatus } from './grafana-reachability'
+
+describe('grafana-reachability', () => {
+  it('treats sub-500 responses as reachable', () => {
+    expect(isGrafanaReachabilityStatus(200)).toBe(true)
+    expect(isGrafanaReachabilityStatus(401)).toBe(true)
+    expect(isGrafanaReachabilityStatus(405)).toBe(true)
+    expect(isGrafanaReachabilityStatus(500)).toBe(false)
+    expect(isGrafanaReachabilityStatus(0)).toBe(false)
+  })
+
+  it('returns not_configured when OTLP endpoint env vars are missing', async () => {
+    await expect(checkGrafanaCloudReachability({ env: {} })).resolves.toEqual({
+      reachable: false,
+      reason: 'not_configured'
+    })
+  })
+
+  it('returns reachable when HEAD succeeds', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 405 })
+
+    await expect(
+      checkGrafanaCloudReachability({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com' },
+        fetchImpl
+      })
+    ).resolves.toEqual({ reachable: true })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://otlp.example.com/v1/traces',
+      expect.objectContaining({
+        method: 'HEAD',
+        headers: {}
+      })
+    )
+  })
+
+  it('returns request_failed when HEAD throws or returns server errors', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'))
+
+    await expect(
+      checkGrafanaCloudReachability({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com' },
+        fetchImpl
+      })
+    ).resolves.toEqual({ reachable: false, reason: 'request_failed' })
+
+    fetchImpl.mockResolvedValue({ status: 503 })
+
+    await expect(
+      checkGrafanaCloudReachability({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com' },
+        fetchImpl
+      })
+    ).resolves.toEqual({ reachable: false, reason: 'request_failed' })
+  })
+
+  it('sends configured OTLP headers with the reachability probe', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200 })
+
+    await checkGrafanaCloudReachability({
+      env: {
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com',
+        OTEL_EXPORTER_OTLP_HEADERS: 'Authorization=Basic token'
+      },
+      fetchImpl
+    })
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://otlp.example.com/v1/traces',
+      expect.objectContaining({
+        headers: { Authorization: 'Basic token' }
+      })
+    )
+  })
+
+  it('uses the global fetch implementation by default', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 204 })
+    vi.stubGlobal('fetch', fetchImpl)
+
+    await expect(
+      checkGrafanaCloudReachability({
+        env: { OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp.example.com' }
+      })
+    ).resolves.toEqual({ reachable: true })
+
+    expect(fetchImpl).toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/main/features/telemetry/service/grafana-reachability.ts
+++ b/src/main/features/telemetry/service/grafana-reachability.ts
@@ -1,0 +1,66 @@
+import {
+  readOtlpExportConfig,
+  resolveGrafanaReachabilityUrl,
+  type OtlpExportConfig
+} from '../config/otlp-env'
+
+/** Outcome of probing Grafana Cloud OTLP reachability. */
+export type GrafanaReachabilityResult =
+  | { reachable: true }
+  | { reachable: false; reason: 'not_configured' | 'request_failed' }
+
+const GRAFANA_REACHABILITY_TIMEOUT_MS = 5_000
+
+type FetchLike = typeof fetch
+
+/**
+ * Returns true when the HTTP status indicates the ingest endpoint responded.
+ *
+ * @param status HTTP response status code.
+ * @returns True for responses that prove network reachability.
+ */
+export function isGrafanaReachabilityStatus(status: number): boolean {
+  return status > 0 && status < 500
+}
+
+/**
+ * Probes Grafana Cloud OTLP ingest reachability with a HEAD request.
+ *
+ * @param options Optional fetch implementation and environment overrides (for tests).
+ * @param options.fetchImpl
+ * @param options.env
+ * @returns Reachability result without exposing credentials.
+ */
+export async function checkGrafanaCloudReachability(options?: {
+  fetchImpl?: FetchLike
+  env?: NodeJS.ProcessEnv
+}): Promise<GrafanaReachabilityResult> {
+  const config = readOtlpExportConfig(options?.env)
+
+  if (!config) {
+    return { reachable: false, reason: 'not_configured' }
+  }
+
+  const fetchImpl = options?.fetchImpl ?? fetch
+  const url = resolveGrafanaReachabilityUrl(config, options?.env)
+
+  try {
+    const response = await fetchImpl(url, {
+      method: 'HEAD',
+      headers: buildReachabilityHeaders(config),
+      signal: AbortSignal.timeout(GRAFANA_REACHABILITY_TIMEOUT_MS)
+    })
+
+    if (!isGrafanaReachabilityStatus(response.status)) {
+      return { reachable: false, reason: 'request_failed' }
+    }
+
+    return { reachable: true }
+  } catch {
+    return { reachable: false, reason: 'request_failed' }
+  }
+}
+
+function buildReachabilityHeaders(config: OtlpExportConfig): Record<string, string> {
+  return { ...config.headers }
+}

--- a/src/preload/preload.test.ts
+++ b/src/preload/preload.test.ts
@@ -37,6 +37,10 @@ describe('preload', () => {
     await api.dbHealthcheck()
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('db:healthcheck')
 
+    ipcRenderer.invoke.mockResolvedValueOnce({ reachable: true })
+    await api.checkGrafanaCloudReachability()
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('telemetry:checkGrafanaReachability')
+
     ipcRenderer.invoke.mockResolvedValueOnce('adrian')
     await api.getOsUsername()
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('system:osUsername')

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -11,6 +11,7 @@ const api: ElectronAPI = {
   updateUserDisplayName: (token, displayName) =>
     ipcRenderer.invoke('users:updateDisplayName', { token, displayName }),
   dbHealthcheck: () => ipcRenderer.invoke('db:healthcheck'),
+  checkGrafanaCloudReachability: () => ipcRenderer.invoke('telemetry:checkGrafanaReachability'),
   getOsUsername: () => ipcRenderer.invoke('system:osUsername')
 }
 

--- a/src/renderer/features/authentication/confirm-user/ui/Confirmation.e2e.spec.ts
+++ b/src/renderer/features/authentication/confirm-user/ui/Confirmation.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { gotoHashRoute } from '@shared/tests/e2e/navigation'
 import { waitForOtpInputs } from '@shared/tests/e2e/otp-input'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'

--- a/src/renderer/features/authentication/confirm-user/ui/ResendOneTimePassword.e2e.spec.ts
+++ b/src/renderer/features/authentication/confirm-user/ui/ResendOneTimePassword.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { gotoHashRoute } from '@shared/tests/e2e/navigation'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 

--- a/src/renderer/features/authentication/password-forgotten/ui/EmailStep.e2e.spec.ts
+++ b/src/renderer/features/authentication/password-forgotten/ui/EmailStep.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { gotoHashRoute } from '@shared/tests/e2e/navigation'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 

--- a/src/renderer/features/authentication/password-forgotten/ui/NewPasswordStep.e2e.spec.ts
+++ b/src/renderer/features/authentication/password-forgotten/ui/NewPasswordStep.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import {
   goToPasswordResetNewPasswordStep,
   mockRecoveryFlowRequests

--- a/src/renderer/features/authentication/password-forgotten/ui/OtpStep.e2e.spec.ts
+++ b/src/renderer/features/authentication/password-forgotten/ui/OtpStep.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import {
   goToPasswordResetOtpStep,
   mockRecoveryRequest,

--- a/src/renderer/features/authentication/password-forgotten/ui/PasswordStepper.e2e.spec.ts
+++ b/src/renderer/features/authentication/password-forgotten/ui/PasswordStepper.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 test.describe('PasswordStepper', () => {

--- a/src/renderer/features/authentication/password-forgotten/ui/ResendOneTimePassword.e2e.spec.ts
+++ b/src/renderer/features/authentication/password-forgotten/ui/ResendOneTimePassword.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { goToPasswordResetOtpStep, mockRecoveryRequest } from '@shared/tests/e2e/password-recovery'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 

--- a/src/renderer/features/authentication/register-user/ui/RegisterForm.e2e.spec.ts
+++ b/src/renderer/features/authentication/register-user/ui/RegisterForm.e2e.spec.ts
@@ -1,4 +1,5 @@
-import { expect, type Page, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 function getRegisterForm(page: Page) {

--- a/src/renderer/features/authentication/service/ensure-local-session.test.ts
+++ b/src/renderer/features/authentication/service/ensure-local-session.test.ts
@@ -29,6 +29,7 @@ describe('ensureLocalSessionFromOsUsername', () => {
       revokeLocalSession: vi.fn(),
       updateUserDisplayName: vi.fn(),
       dbHealthcheck: vi.fn(),
+      checkGrafanaCloudReachability: vi.fn(),
       getOsUsername: vi.fn()
     }
   })

--- a/src/renderer/features/authentication/service/resolve-local-auth-session.test.ts
+++ b/src/renderer/features/authentication/service/resolve-local-auth-session.test.ts
@@ -14,6 +14,7 @@ describe('resolveLocalAuthSession', () => {
       revokeLocalSession: vi.fn(),
       updateUserDisplayName: vi.fn(),
       dbHealthcheck: vi.fn(),
+      checkGrafanaCloudReachability: vi.fn(),
       getOsUsername: vi.fn()
     }
   })
@@ -83,6 +84,7 @@ describe('revokeLocalAuthSession', () => {
       revokeLocalSession: vi.fn(),
       updateUserDisplayName: vi.fn(),
       dbHealthcheck: vi.fn(),
+      checkGrafanaCloudReachability: vi.fn(),
       getOsUsername: vi.fn()
     }
   })

--- a/src/renderer/features/authentication/signin-user/ui/LoginForm.e2e.spec.ts
+++ b/src/renderer/features/authentication/signin-user/ui/LoginForm.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { gotoHashRoute } from '@shared/tests/e2e/navigation'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 import { setCloudModeDisabled, setupLoginAvailable } from '@shared/tests/e2e/setup-login-available'

--- a/src/renderer/features/settings/set-language/ui/LanguageSwitch.e2e.spec.ts
+++ b/src/renderer/features/settings/set-language/ui/LanguageSwitch.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 test.describe('LanguageSwitch', () => {

--- a/src/renderer/features/settings/set-theme/ui/ThemeToggle.e2e.spec.ts
+++ b/src/renderer/features/settings/set-theme/ui/ThemeToggle.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 const THEME_STORAGE_KEY = 'dojosphere.settings.theme'

--- a/src/renderer/features/settings/set-username/ui/UsernameEditor.e2e.spec.ts
+++ b/src/renderer/features/settings/set-username/ui/UsernameEditor.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 const LOCAL_SESSION_STORAGE_KEY = 'dojosphere.auth.local.session'

--- a/src/renderer/features/status/cloud-status/ui/CloudStatus.e2e.spec.ts
+++ b/src/renderer/features/status/cloud-status/ui/CloudStatus.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 const CLOUD_STATUS_KEY = 'dojosphere.cloud.status.isCloudUsed'

--- a/src/renderer/features/status/index.ts
+++ b/src/renderer/features/status/index.ts
@@ -10,3 +10,4 @@ export {
   checkHeartbeatConnectivity,
   recheckNetworkStatusAfterFailedUserAction
 } from './service/bootstrap-network-status'
+export { checkGrafanaCloudReachability } from './service/check-grafana-cloud-reachability'

--- a/src/renderer/features/status/model/use-status-state.ts
+++ b/src/renderer/features/status/model/use-status-state.ts
@@ -14,12 +14,16 @@ export function useStatusState() {
   if (!activeStore) {
     return {
       isOnline: ref(getNavigatorOnline()),
-      isCloudUsed: ref(true)
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(false)
     }
   }
 
-  const { isOnline } = newStoreToRefs(useNetworkStatusStore(activeStore))
+  const { isOnline, isSupabaseReachable, isGrafanaCloudReachable } = newStoreToRefs(
+    useNetworkStatusStore(activeStore)
+  )
   const { isCloudUsed } = newStoreToRefs(useCloudStatusStore(activeStore))
 
-  return { isOnline, isCloudUsed }
+  return { isOnline, isCloudUsed, isSupabaseReachable, isGrafanaCloudReachable }
 }

--- a/src/renderer/features/status/network-status/model/use-network-status.test.ts
+++ b/src/renderer/features/status/network-status/model/use-network-status.test.ts
@@ -20,8 +20,15 @@ describe('useNetworkStatus', () => {
     const { useStatusState } = await import('../../model/use-status-state')
     const isOnline = ref(true)
     const isCloudUsed = ref(false)
+    const isSupabaseReachable = ref(true)
+    const isGrafanaCloudReachable = ref(false)
 
-    vi.mocked(useStatusState).mockReturnValue({ isOnline, isCloudUsed })
+    vi.mocked(useStatusState).mockReturnValue({
+      isOnline,
+      isCloudUsed,
+      isSupabaseReachable,
+      isGrafanaCloudReachable
+    })
 
     const result = useNetworkStatus()
 
@@ -35,8 +42,15 @@ describe('useNetworkStatus', () => {
       await import('../../service/bootstrap-network-status')
     const isOnline = ref(false)
     const isCloudUsed = ref(false)
+    const isSupabaseReachable = ref(false)
+    const isGrafanaCloudReachable = ref(false)
 
-    vi.mocked(useStatusState).mockReturnValue({ isOnline, isCloudUsed })
+    vi.mocked(useStatusState).mockReturnValue({
+      isOnline,
+      isCloudUsed,
+      isSupabaseReachable,
+      isGrafanaCloudReachable
+    })
     vi.mocked(recheckNetworkStatusAfterFailedUserAction).mockResolvedValue(true)
 
     const result = useNetworkStatus()

--- a/src/renderer/features/status/network-status/store/use-network-status-store.test.ts
+++ b/src/renderer/features/status/network-status/store/use-network-status-store.test.ts
@@ -12,6 +12,8 @@ describe('useNetworkStatusStore', () => {
     const store = useNetworkStatusStore()
 
     expect(store.isOnline).toBe(true)
+    expect(store.isSupabaseReachable).toBe(true)
+    expect(store.isGrafanaCloudReachable).toBe(false)
   })
 
   it('updates online state through action', () => {
@@ -22,5 +24,15 @@ describe('useNetworkStatusStore', () => {
 
     store.setOnline(true)
     expect(store.isOnline).toBe(true)
+  })
+
+  it('updates reachability flags independently', () => {
+    const store = useNetworkStatusStore()
+
+    store.setSupabaseReachable(false)
+    store.setGrafanaCloudReachable(true)
+
+    expect(store.isSupabaseReachable).toBe(false)
+    expect(store.isGrafanaCloudReachable).toBe(true)
   })
 })

--- a/src/renderer/features/status/network-status/store/use-network-status-store.ts
+++ b/src/renderer/features/status/network-status/store/use-network-status-store.ts
@@ -3,11 +3,19 @@ import { newStore } from '@shared/lib/pinia/store-define'
 /** Pinia store tracking runtime network reachability. */
 export const useNetworkStatusStore = newStore('network-status', {
   state: () => ({
-    isOnline: true
+    isOnline: true,
+    isSupabaseReachable: true,
+    isGrafanaCloudReachable: false
   }),
   actions: {
     setOnline(value: boolean) {
       this.isOnline = value
+    },
+    setSupabaseReachable(value: boolean) {
+      this.isSupabaseReachable = value
+    },
+    setGrafanaCloudReachable(value: boolean) {
+      this.isGrafanaCloudReachable = value
     }
   }
 })

--- a/src/renderer/features/status/network-status/ui/NetworkStatus.e2e.spec.ts
+++ b/src/renderer/features/status/network-status/ui/NetworkStatus.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 test.describe('NetworkStatus', () => {

--- a/src/renderer/features/status/service/bootstrap-network-status.test.ts
+++ b/src/renderer/features/status/service/bootstrap-network-status.test.ts
@@ -10,6 +10,13 @@ vi.mock('@shared/api', () => ({
   heartbeat: vi.fn()
 }))
 
+vi.mock('./check-grafana-cloud-reachability', () => ({
+  checkGrafanaCloudReachability: vi.fn().mockResolvedValue({
+    reachable: false,
+    reason: 'not_configured'
+  })
+}))
+
 vi.mock('../monitoring/monitoring', () => ({
   monitorDebug,
   monitorInformation,
@@ -51,12 +58,13 @@ async function loadBootstrapModule() {
 
   const bootstrap = await import('./bootstrap-network-status')
   const api = await import('@shared/api')
+  const grafana = await import('./check-grafana-cloud-reachability')
   const logging = await import('@shared/lib')
   const statusState = await import('../model/use-status-state')
   const networkStore = await import('../network-status/store/use-network-status-store')
   const cloudStore = await import('../cloud-status/store/use-cloud-status-store')
 
-  return { bootstrap, api, logging, statusState, networkStore, cloudStore }
+  return { bootstrap, api, grafana, logging, statusState, networkStore, cloudStore }
 }
 
 async function loadStatusStateWithoutActiveStore() {
@@ -143,6 +151,25 @@ describe('bootstrapNetworkStatus', () => {
     expect(logging.captureException).toHaveBeenCalledTimes(1)
   })
 
+  it('tracks Supabase and Grafana reachability separately during bootstrap', async () => {
+    const { bootstrap, api, grafana, networkStore } = await loadBootstrapModule()
+    vi.mocked(api.heartbeat).mockResolvedValue({
+      data: { status: 'ok', timestamp: '2026-05-20T10:00:00.000Z' },
+      error: null
+    } as Awaited<ReturnType<typeof api.heartbeat>>)
+    vi.mocked(grafana.checkGrafanaCloudReachability).mockResolvedValue({
+      reachable: false,
+      reason: 'request_failed'
+    })
+
+    await bootstrap.bootstrapNetworkStatus()
+
+    const store = networkStore.useNetworkStatusStore()
+    expect(store.isSupabaseReachable).toBe(true)
+    expect(store.isGrafanaCloudReachable).toBe(false)
+    expect(store.isOnline).toBe(true)
+  })
+
   it('initializes stores and browser listeners on bootstrap', async () => {
     const { bootstrap, api, networkStore, cloudStore } = await loadBootstrapModule()
     const addListenerSpy = vi.spyOn(globalThis.window, 'addEventListener')
@@ -166,6 +193,8 @@ describe('bootstrapNetworkStatus', () => {
     setNavigatorOnline(false)
     ;(offlineHandler as (event: unknown) => void)(new globalThis.Event('offline'))
     expect(networkStatusStore.isOnline).toBe(false)
+    expect(networkStatusStore.isSupabaseReachable).toBe(false)
+    expect(networkStatusStore.isGrafanaCloudReachable).toBe(false)
     expect(cloudStatusStore.isCloudUsed).toBe(true)
 
     setNavigatorOnline(true)

--- a/src/renderer/features/status/service/bootstrap-network-status.ts
+++ b/src/renderer/features/status/service/bootstrap-network-status.ts
@@ -6,6 +6,7 @@ import { bindConnectivityState } from '@shared/model'
 import { useStatusState } from '../model/use-status-state'
 import { MONITORING_EVENTS, monitorWarning } from '../monitoring/monitoring'
 import { useNetworkStatusStore } from '../network-status/store'
+import { checkGrafanaCloudReachability } from './check-grafana-cloud-reachability'
 
 /** Result of checking backend connectivity via the heartbeat edge function. */
 export type HeartbeatCheckResult = { success: true } | { success: false; error: AppError }
@@ -62,19 +63,27 @@ export async function checkHeartbeatConnectivity(): Promise<HeartbeatCheckResult
 
 function setOfflineState() {
   monitorWarning(MONITORING_EVENTS.CONNECTIVITY_OFFLINE)
-  useNetworkStatusStore().setOnline(false)
+  const store = useNetworkStatusStore()
+  store.setOnline(false)
+  store.setSupabaseReachable(false)
+  store.setGrafanaCloudReachable(false)
 }
 
-async function runHeartbeatCheck(): Promise<boolean> {
+async function runConnectivityChecks(): Promise<boolean> {
   if (!getNavigatorOnline()) {
     setOfflineState()
     return false
   }
 
-  const isReachable = (await checkHeartbeatConnectivity()).success
-  useNetworkStatusStore().setOnline(isReachable)
+  const isSupabaseReachable = (await checkHeartbeatConnectivity()).success
+  const store = useNetworkStatusStore()
+  store.setSupabaseReachable(isSupabaseReachable)
+  store.setOnline(isSupabaseReachable)
 
-  return isReachable
+  const grafanaResult = await checkGrafanaCloudReachability()
+  store.setGrafanaCloudReachable(grafanaResult.reachable)
+
+  return isSupabaseReachable
 }
 
 let hasNetworkStatusBootstrap = false
@@ -93,7 +102,7 @@ export async function bootstrapNetworkStatus(): Promise<void> {
   useNetworkStatusStore().setOnline(getNavigatorOnline())
 
   if (getNavigatorOnline()) {
-    await runHeartbeatCheck()
+    await runConnectivityChecks()
   } else {
     setOfflineState()
   }
@@ -103,7 +112,7 @@ export async function bootstrapNetworkStatus(): Promise<void> {
   }
 
   globalThis.window.addEventListener('online', () => {
-    void runHeartbeatCheck()
+    void runConnectivityChecks()
   })
   globalThis.window.addEventListener('offline', setOfflineState)
 }
@@ -113,5 +122,5 @@ export async function bootstrapNetworkStatus(): Promise<void> {
  * @returns True when backend heartbeat succeeds, otherwise false.
  */
 export async function recheckNetworkStatusAfterFailedUserAction(): Promise<boolean> {
-  return await runHeartbeatCheck()
+  return await runConnectivityChecks()
 }

--- a/src/renderer/features/status/service/check-grafana-cloud-reachability.test.ts
+++ b/src/renderer/features/status/service/check-grafana-cloud-reachability.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('checkGrafanaCloudReachability', () => {
+  it('returns not_configured when Electron IPC is unavailable', async () => {
+    vi.stubGlobal('window', undefined)
+
+    const { checkGrafanaCloudReachability } = await import('./check-grafana-cloud-reachability')
+
+    await expect(checkGrafanaCloudReachability()).resolves.toEqual({
+      reachable: false,
+      reason: 'not_configured'
+    })
+
+    vi.unstubAllGlobals()
+  })
+
+  it('delegates to window.api when available', async () => {
+    const invoke = vi.fn().mockResolvedValue({ reachable: true })
+    vi.stubGlobal('window', { api: { checkGrafanaCloudReachability: invoke } })
+
+    const { checkGrafanaCloudReachability } = await import('./check-grafana-cloud-reachability')
+
+    await expect(checkGrafanaCloudReachability()).resolves.toEqual({ reachable: true })
+    expect(invoke).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/renderer/features/status/service/check-grafana-cloud-reachability.ts
+++ b/src/renderer/features/status/service/check-grafana-cloud-reachability.ts
@@ -1,0 +1,16 @@
+import type { GrafanaReachabilityResult } from '@shared/types/electron-api'
+
+/**
+ * Probes Grafana Cloud OTLP reachability through the main process.
+ *
+ * @returns Reachability result, or unreachable when Electron IPC is unavailable.
+ */
+export async function checkGrafanaCloudReachability(): Promise<GrafanaReachabilityResult> {
+  const invoke = globalThis.window?.api?.checkGrafanaCloudReachability
+
+  if (!invoke) {
+    return { reachable: false, reason: 'not_configured' }
+  }
+
+  return await invoke()
+}

--- a/src/renderer/pages/account/ui/Account.e2e.spec.ts
+++ b/src/renderer/pages/account/ui/Account.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 
 test.describe('account page', () => {
   test('redirects unauthenticated users to login with redirect query', async ({ page }) => {

--- a/src/renderer/pages/dashboard/ui/Welcome.e2e.spec.ts
+++ b/src/renderer/pages/dashboard/ui/Welcome.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 
 test.describe('dashboard page', () => {
   test('bootstraps local auth on app start and shows dashboard', async ({ page }) => {

--- a/src/renderer/pages/login/ui/Login.e2e.spec.ts
+++ b/src/renderer/pages/login/ui/Login.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 
 test.describe('login page', () => {
   test('login route renders', async ({ page }) => {

--- a/src/renderer/shared/api/supabase/auth/auth.test.ts
+++ b/src/renderer/shared/api/supabase/auth/auth.test.ts
@@ -1,6 +1,10 @@
 import { captureException } from '@shared/lib'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { isSupabaseRequestAllowed } = vi.hoisted(() => ({
+  isSupabaseRequestAllowed: vi.fn(() => true)
+}))
+
 import { supabase } from '../client'
 import {
   type AuthError,
@@ -47,12 +51,22 @@ vi.mock('@shared/lib', () => ({
   setUserContext: vi.fn()
 }))
 
+vi.mock('../connectivity-guard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../connectivity-guard')>()
+
+  return {
+    ...actual,
+    isSupabaseRequestAllowed
+  }
+})
+
 describe('signUpByEmailPassword', () => {
   const email = 'test@example.com'
   const password = 'password123'
 
   beforeEach(() => {
     vi.clearAllMocks()
+    isSupabaseRequestAllowed.mockReturnValue(true)
   })
 
   it('calls supabase.auth.signUp with correct parameters', async () => {
@@ -379,5 +393,62 @@ describe('updateUserPassword', () => {
       password: 'new-password-123'
     })
     expect(result).toEqual(mockResponse)
+  })
+})
+
+describe('supabase connectivity guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isSupabaseRequestAllowed.mockReturnValue(false)
+  })
+
+  it('blocks auth API calls when Supabase is unreachable', async () => {
+    await expect(signInWithOtp('test@example.com')).resolves.toMatchObject({
+      data: { user: null, session: null },
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(requestPasswordRecovery('test@example.com')).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(getCurrentUser()).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(getCurrentSession()).resolves.toBeNull()
+    await expect(signUpByEmailPassword('test@example.com', 'password')).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(signInByEmailPassword('test@example.com', 'password')).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(signOut()).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(
+      verifyOneTimePasswordBySignUp('test@example.com', '123456')
+    ).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(
+      verifyOneTimePasswordByRecovery('test@example.com', '123456')
+    ).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(resendSignUpConfirmation('test@example.com')).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+    await expect(updateUserPassword('new-password')).resolves.toMatchObject({
+      error: expect.objectContaining({ code: 'network_error' })
+    })
+
+    expect(supabase.auth.signInWithOtp).not.toHaveBeenCalled()
+    expect(supabase.auth.resetPasswordForEmail).not.toHaveBeenCalled()
+    expect(supabase.auth.getUser).not.toHaveBeenCalled()
+    expect(supabase.auth.getSession).not.toHaveBeenCalled()
+    expect(supabase.auth.signUp).not.toHaveBeenCalled()
+    expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled()
+    expect(supabase.auth.signOut).not.toHaveBeenCalled()
+    expect(supabase.auth.verifyOtp).not.toHaveBeenCalled()
+    expect(supabase.auth.resend).not.toHaveBeenCalled()
+    expect(supabase.auth.updateUser).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/shared/api/supabase/auth/auth.ts
+++ b/src/renderer/shared/api/supabase/auth/auth.ts
@@ -1,7 +1,15 @@
 import { captureException } from '@shared/lib'
 
 import { supabase } from '../client'
+import { createSupabaseUnreachableAuthError, isSupabaseRequestAllowed } from '../connectivity-guard'
 import type { AuthChangeEvent, AuthResponse, Session, UserResponse } from '../types/auth-user'
+
+function blockedAuthResponse(): AuthResponse {
+  return {
+    data: { user: null, session: null },
+    error: createSupabaseUnreachableAuthError()
+  }
+}
 
 /**
  * Initiates the sign-in process using a one-time password (OTP) sent to the user's email.
@@ -12,6 +20,10 @@ import type { AuthChangeEvent, AuthResponse, Session, UserResponse } from '../ty
  * @returns A promise that resolves to an AuthResponse.
  */
 export async function signInWithOtp(email: string): Promise<AuthResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return blockedAuthResponse()
+  }
+
   return await supabase.auth.signInWithOtp({
     email,
     options: {
@@ -32,6 +44,10 @@ export async function signInWithOtp(email: string): Promise<AuthResponse> {
 export async function requestPasswordRecovery(
   email: string
 ): Promise<Awaited<ReturnType<typeof supabase.auth.resetPasswordForEmail>>> {
+  if (!isSupabaseRequestAllowed()) {
+    return { data: null, error: createSupabaseUnreachableAuthError() }
+  }
+
   return await supabase.auth.resetPasswordForEmail(email)
 }
 
@@ -44,6 +60,10 @@ export async function requestPasswordRecovery(
  * @returns The current authenticated user or null if no user is logged in or an error occurs.
  */
 export async function getCurrentUser(): Promise<UserResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return { data: { user: null }, error: createSupabaseUnreachableAuthError() }
+  }
+
   return await supabase.auth.getUser()
 }
 
@@ -53,6 +73,10 @@ export async function getCurrentUser(): Promise<UserResponse> {
  * @returns The current session or null if no session exists or an error occurred.
  */
 export async function getCurrentSession(): Promise<Session | null> {
+  if (!isSupabaseRequestAllowed()) {
+    return null
+  }
+
   try {
     const { data, error } = await supabase.auth.getSession()
 
@@ -114,6 +138,10 @@ export async function signUpByEmailPassword(
   email: string,
   password: string
 ): Promise<AuthResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return blockedAuthResponse()
+  }
+
   return supabase.auth.signUp({ email, password })
 }
 
@@ -130,6 +158,10 @@ export async function signInByEmailPassword(
   email: string,
   password: string
 ): Promise<AuthResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return blockedAuthResponse()
+  }
+
   return supabase.auth.signInWithPassword({ email, password })
 }
 
@@ -142,6 +174,10 @@ export async function signInByEmailPassword(
  * @returns Raw Supabase sign-out response.
  */
 export async function signOut(): Promise<Awaited<ReturnType<typeof supabase.auth.signOut>>> {
+  if (!isSupabaseRequestAllowed()) {
+    return { error: createSupabaseUnreachableAuthError() }
+  }
+
   return await supabase.auth.signOut()
 }
 
@@ -172,6 +208,10 @@ export async function verifyOneTimePasswordBySignUp(
   email: string,
   token: string
 ): Promise<AuthResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return blockedAuthResponse()
+  }
+
   return await supabase.auth.verifyOtp({
     email,
     token,
@@ -192,6 +232,10 @@ export async function verifyOneTimePasswordByRecovery(
   email: string,
   token: string
 ): Promise<AuthResponse> {
+  if (!isSupabaseRequestAllowed()) {
+    return blockedAuthResponse()
+  }
+
   return await supabase.auth.verifyOtp({
     email,
     token,
@@ -211,6 +255,13 @@ export async function verifyOneTimePasswordByRecovery(
 export async function resendSignUpConfirmation(
   email: string
 ): Promise<Awaited<ReturnType<typeof supabase.auth.resend>>> {
+  if (!isSupabaseRequestAllowed()) {
+    return {
+      data: { user: null, session: null },
+      error: createSupabaseUnreachableAuthError()
+    }
+  }
+
   return await supabase.auth.resend({
     type: 'signup',
     email
@@ -229,5 +280,9 @@ export async function resendSignUpConfirmation(
 export async function updateUserPassword(
   newPassword: string
 ): Promise<Awaited<ReturnType<typeof supabase.auth.updateUser>>> {
+  if (!isSupabaseRequestAllowed()) {
+    return { data: { user: null }, error: createSupabaseUnreachableAuthError() }
+  }
+
   return await supabase.auth.updateUser({ password: newPassword })
 }

--- a/src/renderer/shared/api/supabase/connectivity-guard.test.ts
+++ b/src/renderer/shared/api/supabase/connectivity-guard.test.ts
@@ -1,0 +1,36 @@
+import { ref } from 'vue'
+import { bindConnectivityState } from '@shared/model/connectivity-state'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createSupabaseUnreachableAuthError, isSupabaseRequestAllowed } from './connectivity-guard'
+
+describe('connectivity-guard', () => {
+  afterEach(() => {
+    bindConnectivityState({
+      isOnline: ref(true),
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(false)
+    })
+  })
+
+  it('blocks requests when Supabase is unreachable', () => {
+    bindConnectivityState({
+      isOnline: ref(false),
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(false),
+      isGrafanaCloudReachable: ref(false)
+    })
+
+    expect(isSupabaseRequestAllowed()).toBe(false)
+  })
+
+  it('creates a retryable auth error for blocked requests', () => {
+    const error = createSupabaseUnreachableAuthError()
+
+    expect(error.status).toBe(0)
+    expect(error.code).toBe('network_error')
+    expect(error.message).toContain('Failed to fetch')
+    expect(error.toJSON()).toEqual({})
+  })
+})

--- a/src/renderer/shared/api/supabase/connectivity-guard.ts
+++ b/src/renderer/shared/api/supabase/connectivity-guard.ts
@@ -1,0 +1,27 @@
+import { useNetworkStatusState } from '@shared/model/connectivity-state'
+import type { AuthError } from '@supabase/supabase-js'
+
+/**
+ * Creates a retryable auth error when Supabase requests are blocked by connectivity gates.
+ *
+ * @returns Auth error compatible with {@link mapSupabaseError}.
+ */
+export function createSupabaseUnreachableAuthError(): AuthError {
+  return {
+    name: 'AuthRetryableFetchError',
+    message: 'Failed to fetch',
+    status: 0,
+    code: 'network_error',
+    __isAuthError: true,
+    toJSON: () => ({})
+  } as unknown as AuthError
+}
+
+/**
+ * Indicates whether Supabase API calls are allowed based on heartbeat reachability.
+ *
+ * @returns True when the heartbeat gate reports Supabase as reachable.
+ */
+export function isSupabaseRequestAllowed(): boolean {
+  return useNetworkStatusState().isSupabaseReachable.value
+}

--- a/src/renderer/shared/lib/electron/e2e-api.ts
+++ b/src/renderer/shared/lib/electron/e2e-api.ts
@@ -84,6 +84,7 @@ export function installPlaywrightBrowserElectronApi(overrides: Partial<ElectronA
       }
     },
     dbHealthcheck: async () => ({ ok: true, version: 'playwright-browser' }),
+    checkGrafanaCloudReachability: async () => ({ reachable: false, reason: 'not_configured' }),
     getOsUsername: async () => 'TestUser',
     ...overrides
   }

--- a/src/renderer/shared/lib/index.ts
+++ b/src/renderer/shared/lib/index.ts
@@ -11,7 +11,11 @@ export {
   clearUserContext,
   setUserContext
 } from './telemetry/logging'
-export { setCloudModeMonitoringCheck, shouldCaptureTelemetry } from './telemetry/monitoring-guard'
+export {
+  setCloudModeMonitoringCheck,
+  shouldCaptureTelemetry,
+  shouldUploadTelemetry
+} from './telemetry/monitoring-guard'
 export { createMonitoringHelpers, type MonitoringHelpers } from './telemetry/monitoring-helpers'
 export { registerGlobalErrorHandlers } from './telemetry/register-global-error-handlers'
 export { ErrorCode, errorTranslationMap, translateError } from './validation/error-manager'

--- a/src/renderer/shared/lib/telemetry/monitoring-guard.test.ts
+++ b/src/renderer/shared/lib/telemetry/monitoring-guard.test.ts
@@ -1,15 +1,24 @@
+import { ref } from 'vue'
+import { bindConnectivityState } from '@shared/model/connectivity-state'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   isCloudModeMonitoringAllowed,
   resetCloudModeMonitoringCheck,
   setCloudModeMonitoringCheck,
-  shouldCaptureTelemetry
+  shouldCaptureTelemetry,
+  shouldUploadTelemetry
 } from './monitoring-guard'
 
 describe('monitoring-guard', () => {
   afterEach(() => {
     resetCloudModeMonitoringCheck()
+    bindConnectivityState({
+      isOnline: ref(true),
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(false)
+    })
   })
 
   it('allows capture regardless of navigator.onLine', () => {
@@ -30,5 +39,41 @@ describe('monitoring-guard', () => {
 
   it('reports cloud mode allowed when check is not registered', () => {
     expect(isCloudModeMonitoringAllowed()).toBe(true)
+  })
+
+  it('blocks upload when cloud mode is off', () => {
+    setCloudModeMonitoringCheck(() => false)
+    bindConnectivityState({
+      isOnline: ref(true),
+      isCloudUsed: ref(false),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(true)
+    })
+
+    expect(shouldUploadTelemetry()).toBe(false)
+  })
+
+  it('blocks upload when heartbeat is ok but Grafana Cloud is down', () => {
+    setCloudModeMonitoringCheck(() => true)
+    bindConnectivityState({
+      isOnline: ref(true),
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(false)
+    })
+
+    expect(shouldUploadTelemetry()).toBe(false)
+  })
+
+  it('allows upload when cloud mode and Grafana Cloud reachability pass', () => {
+    setCloudModeMonitoringCheck(() => true)
+    bindConnectivityState({
+      isOnline: ref(true),
+      isCloudUsed: ref(true),
+      isSupabaseReachable: ref(true),
+      isGrafanaCloudReachable: ref(true)
+    })
+
+    expect(shouldUploadTelemetry()).toBe(true)
   })
 })

--- a/src/renderer/shared/lib/telemetry/monitoring-guard.ts
+++ b/src/renderer/shared/lib/telemetry/monitoring-guard.ts
@@ -1,3 +1,5 @@
+import { useNetworkStatusState } from '@shared/model/connectivity-state'
+
 let cloudModeCheck: (() => boolean) | null = null
 
 /**
@@ -26,6 +28,19 @@ export function shouldCaptureTelemetry(): boolean {
  */
 export function isCloudModeMonitoringAllowed(): boolean {
   return cloudModeCheck?.() ?? true
+}
+
+/**
+ * Indicates whether telemetry upload to Grafana Cloud should proceed.
+ *
+ * @returns True when cloud mode is on and Grafana Cloud is reachable.
+ */
+export function shouldUploadTelemetry(): boolean {
+  if (!isCloudModeMonitoringAllowed()) {
+    return false
+  }
+
+  return useNetworkStatusState().isGrafanaCloudReachable.value
 }
 
 /**

--- a/src/renderer/shared/model/connectivity-state.test.ts
+++ b/src/renderer/shared/model/connectivity-state.test.ts
@@ -26,26 +26,41 @@ describe('connectivity-state', () => {
 
     expect(state.isOnline.value).toBe(false)
     expect(state.isCloudUsed.value).toBe(true)
+    expect(state.isSupabaseReachable.value).toBe(true)
+    expect(state.isGrafanaCloudReachable.value).toBe(false)
   })
 
   it('returns bound refs after bindConnectivityState', async () => {
     const { bindConnectivityState, useNetworkStatusState } = await loadConnectivityState()
     const isOnline = ref(false)
     const isCloudUsed = ref(false)
+    const isSupabaseReachable = ref(false)
+    const isGrafanaCloudReachable = ref(true)
 
-    bindConnectivityState({ isOnline, isCloudUsed })
+    bindConnectivityState({
+      isOnline,
+      isCloudUsed,
+      isSupabaseReachable,
+      isGrafanaCloudReachable
+    })
 
     const state = useNetworkStatusState()
 
     expect(state.isOnline).toBe(isOnline)
     expect(state.isCloudUsed).toBe(isCloudUsed)
+    expect(state.isSupabaseReachable).toBe(isSupabaseReachable)
+    expect(state.isGrafanaCloudReachable).toBe(isGrafanaCloudReachable)
     expect(state.isOnline.value).toBe(false)
     expect(state.isCloudUsed.value).toBe(false)
+    expect(state.isSupabaseReachable.value).toBe(false)
+    expect(state.isGrafanaCloudReachable.value).toBe(true)
 
     isOnline.value = true
     isCloudUsed.value = true
+    isSupabaseReachable.value = true
 
     expect(useNetworkStatusState().isOnline.value).toBe(true)
     expect(useNetworkStatusState().isCloudUsed.value).toBe(true)
+    expect(useNetworkStatusState().isSupabaseReachable.value).toBe(true)
   })
 })

--- a/src/renderer/shared/model/connectivity-state.ts
+++ b/src/renderer/shared/model/connectivity-state.ts
@@ -1,14 +1,18 @@
 import { type Ref, ref } from 'vue'
-import { getNavigatorOnline } from '@shared/lib'
+import { getNavigatorOnline } from '@shared/lib/browser/navigator'
 
 type ConnectivityRefs = {
   isOnline: Ref<boolean>
   isCloudUsed: Ref<boolean>
+  isSupabaseReachable: Ref<boolean>
+  isGrafanaCloudReachable: Ref<boolean>
 }
 
 let connectivityState: ConnectivityRefs = {
   isOnline: ref(getNavigatorOnline()),
-  isCloudUsed: ref(true)
+  isCloudUsed: ref(true),
+  isSupabaseReachable: ref(true),
+  isGrafanaCloudReachable: ref(false)
 }
 
 /**

--- a/src/renderer/shared/tests/e2e/fixtures.test.ts
+++ b/src/renderer/shared/tests/e2e/fixtures.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setEnglishLanguage } = vi.hoisted(() => ({
+  setEnglishLanguage: vi.fn()
+}))
+
+const { mockHeartbeatSuccess } = vi.hoisted(() => ({
+  mockHeartbeatSuccess: vi.fn()
+}))
+
+type PageFixture = (
+  args: { page: { route: ReturnType<typeof vi.fn> } },
+  use: (page: { route: ReturnType<typeof vi.fn> }) => Promise<void>
+) => Promise<void>
+
+const { capturedPageFixture } = vi.hoisted(() => ({
+  capturedPageFixture: { current: undefined as PageFixture | undefined }
+}))
+
+vi.mock('./setup-language', () => ({
+  setEnglishLanguage
+}))
+
+vi.mock('./setup-login-available', () => ({
+  mockHeartbeatSuccess
+}))
+
+vi.mock('@playwright/test', () => ({
+  expect: vi.fn(),
+  test: {
+    extend: vi.fn((fixtures: { page: PageFixture }) => {
+      capturedPageFixture.current = fixtures.page
+
+      return {
+        extend: vi.fn()
+      }
+    })
+  }
+}))
+
+describe('e2e fixtures', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    capturedPageFixture.current = undefined
+    await import('./fixtures')
+  })
+
+  it('registers page defaults for language and heartbeat reachability', async () => {
+    expect(capturedPageFixture.current).toBeTypeOf('function')
+
+    const use = vi.fn()
+    const page = { route: vi.fn() }
+
+    await capturedPageFixture.current!({ page }, use)
+
+    expect(setEnglishLanguage).toHaveBeenCalledWith(page)
+    expect(mockHeartbeatSuccess).toHaveBeenCalledWith(page)
+    expect(use).toHaveBeenCalledWith(page)
+  })
+})

--- a/src/renderer/shared/tests/e2e/fixtures.ts
+++ b/src/renderer/shared/tests/e2e/fixtures.ts
@@ -1,0 +1,20 @@
+import { expect, test as base } from '@playwright/test'
+
+import { setEnglishLanguage } from './setup-language'
+import { mockHeartbeatSuccess } from './setup-login-available'
+
+/**
+ * Playwright test fixture with stable defaults for browser-only e2e runs.
+ *
+ * Mocks Supabase heartbeat reachability so auth calls are not blocked when
+ * no local Supabase stack is running (e.g. CI).
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await setEnglishLanguage(page)
+    await mockHeartbeatSuccess(page)
+    await use(page)
+  }
+})
+
+export { expect }

--- a/src/renderer/shared/tests/e2e/password-recovery.test.ts
+++ b/src/renderer/shared/tests/e2e/password-recovery.test.ts
@@ -134,13 +134,14 @@ describe('password-recovery e2e helpers', () => {
     })
   })
 
-  it('registers both request and verify endpoint mocks', async () => {
+  it('registers heartbeat, request and verify endpoint mocks', async () => {
     const { page, route } = createPageDouble()
 
     await mockRecoveryFlowRequests(page as never)
 
-    expect(route).toHaveBeenNthCalledWith(1, '**/auth/v1/recover**', expect.any(Function))
-    expect(route).toHaveBeenNthCalledWith(2, '**/auth/v1/verify**', expect.any(Function))
+    expect(route).toHaveBeenNthCalledWith(1, '**/functions/v1/heartbeat', expect.any(Function))
+    expect(route).toHaveBeenNthCalledWith(2, '**/auth/v1/recover**', expect.any(Function))
+    expect(route).toHaveBeenNthCalledWith(3, '**/auth/v1/verify**', expect.any(Function))
   })
 
   it('navigates to otp step with default email', async () => {

--- a/src/renderer/shared/tests/e2e/password-recovery.ts
+++ b/src/renderer/shared/tests/e2e/password-recovery.ts
@@ -1,6 +1,7 @@
 import { expect, type Page, type Route } from '@playwright/test'
 
 import { typeOtp, waitForPasswordResetOtpStep } from './otp-input'
+import { mockHeartbeatSuccess } from './setup-login-available'
 
 async function fulfillWithSuccess(route: Route): Promise<void> {
   await route.fulfill({
@@ -36,6 +37,7 @@ export async function mockRecoveryVerify(page: Page): Promise<void> {
  * @param page - Playwright page instance.
  */
 export async function mockRecoveryFlowRequests(page: Page): Promise<void> {
+  await mockHeartbeatSuccess(page)
   await mockRecoveryRequest(page)
   await mockRecoveryVerify(page)
 }

--- a/src/renderer/shared/types/electron-api.ts
+++ b/src/renderer/shared/types/electron-api.ts
@@ -1,3 +1,8 @@
+/** Result of probing Grafana Cloud OTLP reachability via main-process IPC. */
+export type GrafanaReachabilityResult =
+  | { reachable: true }
+  | { reachable: false; reason: 'not_configured' | 'request_failed' }
+
 /** Result of a SQLite health check exposed over IPC. */
 export interface DbHealthcheckResult {
   ok: boolean
@@ -53,5 +58,6 @@ export interface ElectronAPI {
   revokeLocalSession: (token: string) => Promise<void>
   updateUserDisplayName: (token: string, displayName: string) => Promise<User>
   dbHealthcheck: () => Promise<DbHealthcheckResult>
+  checkGrafanaCloudReachability: () => Promise<GrafanaReachabilityResult>
   getOsUsername: () => Promise<string>
 }

--- a/src/renderer/shared/ui/OtpInput.e2e.spec.ts
+++ b/src/renderer/shared/ui/OtpInput.e2e.spec.ts
@@ -1,4 +1,5 @@
-import { expect, type Page, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { gotoHashRoute } from '@shared/tests/e2e/navigation'
 import { getOtpInputs, typeOtp } from '@shared/tests/e2e/otp-input'
 

--- a/src/renderer/widgets/navigation/ui/BottomNavigation.e2e.spec.ts
+++ b/src/renderer/widgets/navigation/ui/BottomNavigation.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@shared/tests/e2e/fixtures'
 import { setEnglishLanguage } from '@shared/tests/e2e/setup-language'
 
 const CLOUD_STATUS_KEY = 'dojosphere.cloud.status.isCloudUsed'


### PR DESCRIPTION
- Added environment variables for Grafana Cloud telemetry configuration in `.env.example`.
- Implemented IPC handler for checking Grafana Cloud reachability in the telemetry feature.
- Updated preload API to include `checkGrafanaCloudReachability` method.
- Enhanced network status management to track Grafana Cloud reachability separately.
- Updated tests to cover new telemetry reachability checks and ensure proper functionality.
- Refactored monitoring guard to conditionally allow telemetry uploads based on Grafana Cloud reachability.